### PR TITLE
Add GitHub action to compile and install, build and deploy docs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: "Compile and Deploy Documentation"
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Compile with docs and install
+      uses: ./docker-action
+
+    - name: Touch .nojekyll
+      run: |
+        touch html/.nojekyll
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        # PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./html
+      with:
+        forceOrphan: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: "Compile and Deploy Documentation"
 
-on: [push]
+on:
+  push:
+    branches: master
 
 jobs:
   build:

--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:latest
+
+MAINTAINER nobody@a.de
+LABEL description="github actions test"
+
+ENV ROOT_ARCHIVE="root_v6.18.04.Linux-ubuntu18-x86_64-gcc7.4.tar.gz"
+ENV ROOTSYS=/opt/root
+
+RUN apt update && apt install -y \
+    build-essential bash gfortran cmake \
+    libboost-all-dev wget libblas3 python-pip \
+    libxml2-utils \
+    doxygen libxslt1-dev xsltproc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt && cd /opt && \
+    wget https://root.cern/download/${ROOT_ARCHIVE} && \
+    tar xvf ${ROOT_ARCHIVE} && \
+    rm -f ${ROOT_ARCHIVE}
+
+ADD run_action.sh /run_action.sh
+ENTRYPOINT ["/bin/bash", "-x"]
+CMD ["/run_action.sh"]

--- a/docker-action/run_action.sh
+++ b/docker-action/run_action.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+
+source ${ROOTSYS}/bin/thisroot.sh
+
+mkdir /opt/fittino
+
+mkdir build
+pushd build
+
+cmake -DCMAKE_INSTALL_PREFIX=/opt/fittino ..
+make
+make doc
+make install
+
+popd
+
+cp -rv /opt/fittino/share/doc/fittino/html .
+chmod -R a+rwX ./html


### PR DESCRIPTION
Deploys documentation to GitHub pages.
Build is performed in an `ubuntu:latest` docker container,
uses binary ROOT from `root.cern.ch`.
Does not use SuperBuild, but builds with minimal dependencies.
Needs deployment SSH keys set up.

To set up a deployment SSH keypair, perform the following steps (or similar):
```
ssh-keygen -t rsa -b 4096 -C "$(git config user.email)" -f gh-pages -N ""
```
Go to repository "Settings" => "Secrets" and add a new secret named:
`ACTIONS_DEPLOY_KEY`. 
This must contain the *private* key (full content of the file). 
Then, still for the repository, go to "Settings" => "Deploy keys" and add add the public part of the key (full content of file). This will (expectedly) trigger a notification mail to all repo managers. 

More details and pictures at:
https://github.com/peaceiris/actions-gh-pages#1-add-ssh-deploy-key

That's it, afterwards re-trigger the `action` on the `Actions` tab or commit something (or perform those setup steps before merging this PR). 