### PR TITLE
github-action: Switch to GITHUB_TOKEN usage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./html
         force_orphan: true


### PR DESCRIPTION
Now the SSH key can be dropped,
GitHub silently fixed the issue that tokens did not work
for deployments on public repos.

This means in "settings" of the main repository, the `ACTIONS_DEPLOY_KEY` in the "Secrets" section can be deleted, and the SSH key in "Deploy keys" can be dropped. 